### PR TITLE
SSPROD-27210: Make TF module variables consistent for Agentless scanning

### DIFF
--- a/modules/services/agentless-scanning/main.tf
+++ b/modules/services/agentless-scanning/main.tf
@@ -148,6 +148,7 @@ resource "aws_iam_policy" "agentless" {
   path        = "/sysdig/secure/agentless/"
   description = "Grants Sysdig Secure access to volumes and snapshots"
   policy      = data.aws_iam_policy_document.agentless[0].json
+  tags        = var.tags
 }
 
 data "aws_iam_policy_document" "agentless_assume_role_policy" {

--- a/modules/services/agentless-scanning/main.tf
+++ b/modules/services/agentless-scanning/main.tf
@@ -144,7 +144,7 @@ data "aws_iam_policy_document" "agentless" {
 resource "aws_iam_policy" "agentless" {
   count = var.deploy_global_resources ? 1 : 0
 
-  name        = "sysdig-secure-agentless-assume-role"
+  name        = var.name
   path        = "/sysdig/secure/agentless/"
   description = "Grants Sysdig Secure access to volumes and snapshots"
   policy      = data.aws_iam_policy_document.agentless[0].json
@@ -186,7 +186,7 @@ resource "aws_iam_role" "agentless" {
 resource "aws_iam_policy_attachment" "agentless" {
   count = var.deploy_global_resources ? 1 : 0
 
-  name       = "sysdig-agentless-host-scanning"
+  name       = var.name
   roles      = [aws_iam_role.agentless[0].name]
   policy_arn = aws_iam_policy.agentless[0].arn
 }

--- a/modules/services/agentless-scanning/variables.tf
+++ b/modules/services/agentless-scanning/variables.tf
@@ -17,6 +17,7 @@ variable "kms_key_deletion_window" {
 variable "name" {
   description = "The name of the installation. Assigned to most child resource(s)"
   type        = string
+  default     = "sysdig-secure-scanning"
 }
 
 variable "tags" {
@@ -35,6 +36,7 @@ variable "deploy_global_resources" {
 variable "kms_key_alias" {
   description = "The alias of the KMS key used to encrypt the data plane secrets"
   type        = string
+  default     = "sysdig-secure-scanning"
 }
 
 variable "primary_key" {


### PR DESCRIPTION
<!--
Thank you for your contribution!

## Testing your PR

You can pinpoint the pr changes as terraform module source with following format

```
source                    = "github.com/draios/terraform-aws-secure-for-cloud//examples/organizational-ecs?ref=<BRANCH_NAME>"
```


## General recommendations
Check contribution guidelines at https://github.com/draios/terraform-aws-secure-for-cloud/blob/master/CONTRIBUTE.md#contribution-checklist

For a cleaner PR make sure you follow these recommendations:
- Review modified files and delete small changes that were not intended and maybe slip the commit.
- Use Pull Request Drafts for visibility on Work-In-Progress branches and use them on daily mob/pairing for team review
- Unless an external revision is desired, in order to validate or gather some feedback, you are free to merge as long as **validation checks are green-lighted**

## Checklist

- [ ] If `test/fixtures/*/main.tf` files are modified, update:
    - [ ] the snippets in the README.md file under root folder.
    - [ ] the snippets in the README.md file for the corresponding example.
- [ ] If `examples` folder are modified, update:
    - [ ] README.md file with pertinent changes.
    - [ ] `test/fixtures/*/main.tf` in case the snippet needs modifications.
- [ ] If any architectural change has been made, update the diagrams.

-->
