### PR TITLE
fix(agentless-scanning): make snapshot destination account configurable

### DIFF
--- a/modules/services/agentless-scanning/locals.tf
+++ b/modules/services/agentless-scanning/locals.tf
@@ -1,7 +1,6 @@
 data "aws_caller_identity" "current" {}
 
 locals {
-  account_id           = data.aws_caller_identity.current.account_id
-  caller_arn           = data.aws_caller_identity.current.arn
-  agentless_account_id = "315105463264"
+  account_id = data.aws_caller_identity.current.account_id
+  caller_arn = data.aws_caller_identity.current.arn
 }

--- a/modules/services/agentless-scanning/main.tf
+++ b/modules/services/agentless-scanning/main.tf
@@ -113,7 +113,7 @@ data "aws_iam_policy_document" "agentless" {
       test     = "StringEquals"
       variable = "ec2:Add/userId"
       values = [
-        local.agentless_account_id
+        var.agentless_account_id
       ]
     }
 
@@ -201,7 +201,7 @@ data "aws_iam_policy_document" "key_policy" {
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::${local.agentless_account_id}:root",
+        "arn:aws:iam::${var.agentless_account_id}:root",
         var.trusted_identity,
         aws_iam_role.agentless[0].arn,
       ]

--- a/modules/services/agentless-scanning/variables.tf
+++ b/modules/services/agentless-scanning/variables.tf
@@ -11,6 +11,7 @@ variable "trusted_identity" {
 variable "agentless_account_id" {
   type        = string
   description = "The identifier of the account that will receive volume snapshots"
+  default     = "878070807337"
 }
 
 variable "kms_key_deletion_window" {

--- a/modules/services/agentless-scanning/variables.tf
+++ b/modules/services/agentless-scanning/variables.tf
@@ -8,6 +8,11 @@ variable "trusted_identity" {
   description = "The name of sysdig trusted identity"
 }
 
+variable "agentless_account_id" {
+  type        = string
+  description = "The identifier of the account that will receive volume snapshots"
+}
+
 variable "kms_key_deletion_window" {
   description = "Deletion window for shared KMS key"
   type        = number


### PR DESCRIPTION
Hello folks, I'm adding this change for a few reasons
* the current `local.agentless_account_id` points to our nonprod scanner account, while Customers will need it to point to prod
* we want to be able to make it point to nonprod or prod, thus the change to a `variable`
* I thought it was better not to expose the actual destination account in a public repo _at all_, thus the absence of a default value

This adds an additional constraint on the Onboarding wizard, we'll discuss it internally.