### PR TITLE
fix(scanning): remove policy path

### DIFF
--- a/modules/services/agentless-scanning/main.tf
+++ b/modules/services/agentless-scanning/main.tf
@@ -162,7 +162,6 @@ resource "aws_iam_policy" "agentless" {
   count = (var.deploy_global_resources || var.is_organizational) ? 1 : 0
 
   name        = var.name
-  path        = "/sysdig/secure/agentless/"
   description = "Grants Sysdig Secure access to volumes and snapshots"
   policy      = data.aws_iam_policy_document.agentless[0].json
   tags        = var.tags


### PR DESCRIPTION
fixes an issue where the policy path was non default, and wasn't applied to the role despite attachment.