### PR TITLE
feat(agentless): scanning role can now perform encrypt/decrypt for CMEKs [SSPROD-28216]

### DIFF
--- a/modules/services/agentless-scanning/main.tf
+++ b/modules/services/agentless-scanning/main.tf
@@ -70,7 +70,7 @@ data "aws_iam_policy_document" "scanning" {
       test     = "StringLike"
       variable = "kms:ViaService"
       values = [
-	"ec2.*.amazonaws.com",
+        "ec2.*.amazonaws.com",
       ]
     }
   }

--- a/modules/services/agentless-scanning/main.tf
+++ b/modules/services/agentless-scanning/main.tf
@@ -59,12 +59,12 @@ data "aws_iam_policy_document" "scanning" {
       "kms:Decrypt",
       "kms:ReEncrypt*",
       "kms:GenerateDataKey*",
-      "kms:CreateGrant"
-    ],
+      "kms:CreateGrant",
+    ]
 
     resource = [
       "*"
-    ],
+    ]
 
     condition {
       test     = "StringLike"

--- a/modules/services/agentless-scanning/main.tf
+++ b/modules/services/agentless-scanning/main.tf
@@ -51,7 +51,7 @@ data "aws_iam_policy_document" "scanning" {
   }
 
   statement {
-    sid = "AllowKMSEncryptDecrypt",
+    sid = "AllowKMSEncryptDecrypt"
 
     action = [
       "kms:DescribeKey",

--- a/modules/services/agentless-scanning/main.tf
+++ b/modules/services/agentless-scanning/main.tf
@@ -50,6 +50,31 @@ data "aws_iam_policy_document" "scanning" {
     ]
   }
 
+  statement {
+    sid = "AllowKMSEncryptDecrypt",
+
+    action = [
+      "kms:DescribeKey",
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:CreateGrant"
+    ],
+
+    resource = [
+      "*"
+    ],
+
+    condition {
+      test     = "StringLike"
+      variable = "kms:ViaService"
+      values = [
+	"ec2.*.amazonaws.com",
+      ]
+    }
+  }
+
   # Allows the creation of snapshots.
   statement {
     sid = "CreateTaggedSnapshotFromVolume"

--- a/modules/services/agentless-scanning/main.tf
+++ b/modules/services/agentless-scanning/main.tf
@@ -53,7 +53,7 @@ data "aws_iam_policy_document" "scanning" {
   statement {
     sid = "AllowKMSEncryptDecrypt"
 
-    action = [
+    actions = [
       "kms:DescribeKey",
       "kms:Encrypt",
       "kms:Decrypt",
@@ -62,7 +62,7 @@ data "aws_iam_policy_document" "scanning" {
       "kms:CreateGrant",
     ]
 
-    resource = [
+    resources = [
       "*"
     ]
 

--- a/modules/services/agentless-scanning/organizational.tf
+++ b/modules/services/agentless-scanning/organizational.tf
@@ -76,6 +76,19 @@ Resources:
                     - "kms:ListAliases"
                     - "kms:ListResourceTags"
                   Resource: "*"
+                - Sid: "AllowKMSEncryptDecrypt"
+                  Effect: "Allow"
+                  Action:
+                    - "kms:DescribeKey"
+                    - "kms:Encrypt"
+                    - "kms:Decrypt"
+                    - "kms:ReEncrypt*"
+                    - "kms:GenerateDataKey*"
+                    - "kms:CreateGrant"
+                  Resource: "*"
+                  Condition:
+                    StringLike:
+                      kms:ViaService: ["ec2.*.amazonaws.com"]
                 - Sid: "CreateTaggedSnapshotFromVolume"
                   Effect: "Allow"
                   Action: "ec2:CreateSnapshot"

--- a/modules/services/agentless-scanning/versions.tf
+++ b/modules/services/agentless-scanning/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.2.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
Hello folks, this change adds the possibility to leverage any existing KMS Key used for EBS Encryption.

We're completing our tests, so please don't merge this, let's sync first.