### PR TITLE
SSPROD-28875: Fix region for CSPM Org TF module

### DIFF
--- a/modules/services/trust-relationship/main.tf
+++ b/modules/services/trust-relationship/main.tf
@@ -79,7 +79,7 @@ TEMPLATE
 resource "aws_cloudformation_stack_set_instance" "stackset_instance" {
   count = var.is_organizational ? 1 : 0
 
-  region         = var.region
+  region         = var.region == "" ? null : var.region
   stack_set_name = aws_cloudformation_stack_set.stackset[0].name
   deployment_targets {
     organizational_unit_ids = local.org_units_to_deploy

--- a/modules/services/trust-relationship/variables.tf
+++ b/modules/services/trust-relationship/variables.tf
@@ -32,7 +32,7 @@ variable "org_units" {
 
 variable "region" {
   type        = string
-  default     = "eu-central-1"
+  default     = ""
   description = "Default region for resource creation in organization mode"
 }
 


### PR DESCRIPTION
## Fix summary

- Fix the CSPM org module to create stacksets in region TF variable only if provided, else make region field optional for aws_cloudformation_stack_set_instance.
- Remove `eu-central-1` as the default for region TF variable.

## Testing your PR

Tested the PR successfully with following TF snippet (both with and without `var.region` variable provided as input) :-

```
provider "aws" {
  region = "us-east-1"
}

module "organization-cspm" {
#  source            = "draios/secure-for-cloud/aws//modules/services/trust-relationship"
  source            = "../trust-relationship"
  trusted_identity  = "arn:aws:iam::0646xxxxxxxx:role/us-east-1-integration01-secure-assume-role"
  external_id       = "8114551xxxxxxxxxxxxxxx"
  role_name         = "sysdig-secure-2u6g"
  org_units         = ["ou-op65-xxxx"]
  is_organizational = true
}

module "organization-threat-detection" {
#  source               = "draios/secure-for-cloud/aws//modules/services/event-bridge"
  source               = "../event-bridge"
  target_event_bus_arn = "arn:aws:events:us-east-1:0646xxxxxxxx:event-bus/us-east-1-integration01-falco-1"
  trusted_identity     = "arn:aws:iam::0646xxxxxxxx:role/us-east-1-integration01-secure-assume-role"
  external_id          = "8114551xxxxxxxxxxxxxxx"
  name                 = "sysdig-secure-cloudtrail-i9yc"
  is_organizational    = true
  org_units            = ["ou-op65-xxxx"]
  regions              = ["us-west-1","us-east-1","us-west-2"]
}
```

<!--
Thank you for your contribution!

```
source                    = "github.com/draios/terraform-aws-secure-for-cloud//examples/organizational-ecs?ref=<BRANCH_NAME>"
```


## General recommendations
Check contribution guidelines at https://github.com/draios/terraform-aws-secure-for-cloud/blob/master/CONTRIBUTE.md#contribution-checklist

For a cleaner PR make sure you follow these recommendations:
- Review modified files and delete small changes that were not intended and maybe slip the commit.
- Use Pull Request Drafts for visibility on Work-In-Progress branches and use them on daily mob/pairing for team review
- Unless an external revision is desired, in order to validate or gather some feedback, you are free to merge as long as **validation checks are green-lighted**

## Checklist

- [ ] If `test/fixtures/*/main.tf` files are modified, update:
    - [ ] the snippets in the README.md file under root folder.
    - [ ] the snippets in the README.md file for the corresponding example.
- [ ] If `examples` folder are modified, update:
    - [ ] README.md file with pertinent changes.
    - [ ] `test/fixtures/*/main.tf` in case the snippet needs modifications.
- [ ] If any architectural change has been made, update the diagrams.

-->
