### PR TITLE
feat(trust-relationship) Parallelize role creation in stackset

### DIFF
--- a/modules/services/trust-relationship/main.tf
+++ b/modules/services/trust-relationship/main.tf
@@ -84,4 +84,8 @@ resource "aws_cloudformation_stack_set_instance" "stackset_instance" {
   deployment_targets {
     organizational_unit_ids = local.org_units_to_deploy
   }
+  operation_preferences {
+    failure_tolerance_count = 10
+    max_concurrent_count    = 10
+  }
 }


### PR DESCRIPTION
All other Stacksets use parallelized resource creation except for the TrustRelationship module. This PR adds parallelism to this Stackset. (Note: region parallelism is not needed since roles are only created in one region)