### PR TITLE
fix(trust-relationship, event-bridge) Ignore administration_role changes

### DIFF
--- a/modules/services/event-bridge/organizational.tf
+++ b/modules/services/event-bridge/organizational.tf
@@ -27,6 +27,10 @@ resource "aws_cloudformation_stack_set" "eb-rule-stackset" {
     retain_stacks_on_account_removal = false
   }
 
+  lifecycle {
+    ignore_changes = [administration_role_arn]
+  }
+
   template_body = <<TEMPLATE
 Resources:
   EventBridgeRule:
@@ -87,6 +91,10 @@ resource "aws_cloudformation_stack_set" "eb-role-stackset" {
   auto_deployment {
     enabled                          = true
     retain_stacks_on_account_removal = false
+  }
+
+  lifecycle {
+    ignore_changes = [administration_role_arn]
   }
 
   template_body = <<TEMPLATE

--- a/modules/services/trust-relationship/main.tf
+++ b/modules/services/trust-relationship/main.tf
@@ -56,6 +56,10 @@ resource "aws_cloudformation_stack_set" "stackset" {
     retain_stacks_on_account_removal = false
   }
 
+  lifecycle {
+    ignore_changes = [administration_role_arn]
+  }
+
   template_body = <<TEMPLATE
 Resources:
   SysdigCSPMRole:


### PR DESCRIPTION
There is a bug in the AWS Provider with Service managed stacksets: https://github.com/hashicorp/terraform-provider-aws/issues/23464

This PR applies a workaround to ignore these unintended lifecycle changes.