### PR TITLE
Update terraform S3 access policy to support corner cases 

### DIFF
--- a/modules/services/cloud-logs/README.md
+++ b/modules/services/cloud-logs/README.md
@@ -17,7 +17,7 @@ The following resources will be created in each instrumented account:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.9.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.17.0 |
 
 ## Modules
 
@@ -29,15 +29,15 @@ No modules.
 |------|------|
 | [aws_iam_role.cloudlogs_s3_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_policy_document.assume_cloudlogs_s3_access_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.cloudlogs_s3_access_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.cloudlogs_s3_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | (Required) The name of your s3 bucket associated with your Clloudtrail trail | `string` | n/a | yes |
+| <a name="input_account_id"></a> [account\_id](#input\_account\_id) | (Required) The identifier of your AWS account | `string` | n/a | yes |
+| <a name="input_bucket_arn"></a> [bucket\_arn](#input\_bucket\_arn) | (Required) The ARN of your s3 bucket associated with your Cloudtrail trail | `string` | n/a | yes |
 | <a name="input_external_id"></a> [external\_id](#input\_external\_id) | (Required) Random string generated unique to a customer | `string` | n/a | yes |
-| <a name="input_region"></a> [region](#input\_region) | (Optional) Default region for resource creation | `string` | `"eu-central-1"` | no |
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | (Required) The name of the IAM Role that will enable access to the Cloudtrail logs | `string` | `"cloudtrail-s3-bucket-read-access"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) Sysdig secure-for-cloud tags. always include 'product' default tag for resource-group proper functioning | `map(string)` | <pre>{<br>  "product": "sysdig-secure-for-cloud"<br>}</pre> | no |
 | <a name="input_trusted_identity"></a> [trusted\_identity](#input\_trusted\_identity) | (Required) The name of Sysdig trusted identity | `string` | n/a | yes |

--- a/modules/services/cloud-logs/main.tf
+++ b/modules/services/cloud-logs/main.tf
@@ -46,18 +46,32 @@ data "aws_iam_policy_document" "assume_cloudlogs_s3_access_role" {
 data "aws_iam_policy_document" "cloudlogs_s3_access" {
 
   statement {
-    sid = "CloudlogsS3Access"
+    sid = "CloudlogsS3AccessGet"
 
     effect = "Allow"
 
     actions = [
       "s3:Get*",
-      "s3:List*"
     ]
 
     resources = [
       var.bucket_arn,
       "${var.bucket_arn}/*"
+    ]
+  }
+
+  statement {
+    sid = "CloudlogsS3AccessList"
+
+    effect = "Allow"
+
+    actions = [
+      "s3:List*"
+    ]
+
+    resources = [
+      "${var.bucket_arn}/AWSLogs/${var.account_id}",
+      "${var.bucket_arn}/AWSLogs/${var.account_id}/*"
     ]
   }
 }

--- a/modules/services/cloud-logs/variables.tf
+++ b/modules/services/cloud-logs/variables.tf
@@ -3,6 +3,11 @@ variable "bucket_arn" {
   type        = string
 }
 
+variable "account_id" {
+  description = "(Required) The identifier of your AWS account"
+  type        = string
+}
+
 variable "external_id" {
   type        = string
   description = "(Required) Random string generated unique to a customer"
@@ -27,3 +32,4 @@ variable "trusted_identity" {
   description = "(Required) The name of Sysdig trusted identity"
   type        = string
 }
+

--- a/test/examples/secure_threat_detection_cloud_logs/single/main.tf
+++ b/test/examples/secure_threat_detection_cloud_logs/single/main.tf
@@ -15,4 +15,5 @@ module "single-account-threat-detection" {
   external_id      = "external_id"
   role_name        = "sysdig-secure-single"
   bucket_arn       = "arn:aws:s3:::sample_bucket_name"
+  account_id       = "sample_account_id"
 }


### PR DESCRIPTION
The update to the S3 policy is necessary to properly access the audit logs stored in S3 covering all the corner cases. 

<!--
Thank you for your contribution!

## Testing your PR

You can pinpoint the pr changes as terraform module source with following format

```
source                    = "github.com/draios/terraform-aws-secure-for-cloud//examples/organizational-ecs?ref=<BRANCH_NAME>"
```


## General recommendations
Check contribution guidelines at https://github.com/draios/terraform-aws-secure-for-cloud/blob/master/CONTRIBUTE.md#contribution-checklist

For a cleaner PR make sure you follow these recommendations:
- Review modified files and delete small changes that were not intended and maybe slip the commit.
- Use Pull Request Drafts for visibility on Work-In-Progress branches and use them on daily mob/pairing for team review
- Unless an external revision is desired, in order to validate or gather some feedback, you are free to merge as long as **validation checks are green-lighted**

## Checklist

- [ ] If `test/fixtures/*/main.tf` files are modified, update:
    - [ ] the snippets in the README.md file under root folder.
    - [ ] the snippets in the README.md file for the corresponding example.
- [ ] If `examples` folder are modified, update:
    - [ ] README.md file with pertinent changes.
    - [ ] `test/fixtures/*/main.tf` in case the snippet needs modifications.
- [ ] If any architectural change has been made, update the diagrams.

-->
