### PR TITLE
fix(event-bridge): Add state in cloudwatch event rule resource (SSPROD-34617, SSPROD-34618)

### DIFF
--- a/modules/services/event-bridge/main.tf
+++ b/modules/services/event-bridge/main.tf
@@ -32,6 +32,7 @@ resource "aws_cloudwatch_event_rule" "sysdig" {
   name        = var.name
   description = "Capture all CloudTrail events"
   tags        = var.tags
+  state       = var.rule_state
 
   event_pattern = <<EOF
 {

--- a/modules/services/event-bridge/organizational.tf
+++ b/modules/services/event-bridge/organizational.tf
@@ -43,6 +43,7 @@ Resources:
           - 'AWS API Call via CloudTrail'
           - 'AWS Console Sign In via CloudTrail'
           - 'AWS Service Event via CloudTrail'
+      State: ${var.rule_state}
       Targets:
         - Id: ${var.name}
           Arn: ${var.target_event_bus_arn}

--- a/modules/services/event-bridge/organizational.tf
+++ b/modules/services/event-bridge/organizational.tf
@@ -73,6 +73,7 @@ Resources:
           - 'AWS API Call via CloudTrail'
           - 'AWS Console Sign In via CloudTrail'
           - 'AWS Service Event via CloudTrail'
+      State: ${var.rule_state}
       Targets:
         - Id: ${var.name}
           Arn: ${var.target_event_bus_arn}

--- a/modules/services/event-bridge/variables.tf
+++ b/modules/services/event-bridge/variables.tf
@@ -64,7 +64,7 @@ variable "external_id" {
 }
 
 variable "rule_state" {
-  type = string
+  type        = string
   description = "State of the rule. When state is ENABLED, the rule is enabled for all events except those delivered by CloudTrail. To also enable the rule for events delivered by CloudTrail, set state to ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS."
-  default = "ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS"
+  default     = "ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS"
 }

--- a/modules/services/event-bridge/variables.tf
+++ b/modules/services/event-bridge/variables.tf
@@ -62,3 +62,9 @@ variable "external_id" {
   type        = string
   description = "Random string generated unique to a customer"
 }
+
+variable "rule_state" {
+  type = string
+  description = "State of the rule. When state is ENABLED, the rule is enabled for all events except those delivered by CloudTrail. To also enable the rule for events delivered by CloudTrail, set state to ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS."
+  default = "ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS"
+}

--- a/modules/services/event-bridge/versions.tf
+++ b/modules/services/event-bridge/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.39.0"
+      version = ">= 5.27.0"
     }
   }
 }


### PR DESCRIPTION
Add state in cloudwatch event rule resource that defaults to `ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS` to also enable the rule for events delivered by CloudTrail