### PR TITLE
fix(eventbridge): Add permissions to describe rule and targets

### DIFF
--- a/modules/services/event-bridge/main.tf
+++ b/modules/services/event-bridge/main.tf
@@ -98,21 +98,39 @@ resource "aws_iam_role" "event_bus_invoke_remote_event_bus" {
 EOF
   inline_policy {
     name   = var.name
-    policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Action": [
-                "events:PutEvents"
-            ],
-            "Resource": [
-                "${var.target_event_bus_arn}"
-            ],
-            "Effect": "Allow"
-        }
-    ]
+    policy = data.aws_iam_policy_document.cloud_trail_events.json
+  }
 }
-EOF
+
+# IAM Policy Document used by EventBridge role for the cloudtrail events policy
+data "aws_iam_policy_document" "cloud_trail_events" {
+
+  statement {
+    sid = "CloudTrailEventsPut"
+
+    effect = "Allow"
+
+    actions = [
+      "events:PutEvents",
+    ]
+
+    resources = [
+      var.target_event_bus_arn,
+    ]
+  }
+
+  statement {
+    sid = "CloudTrailEventRuleAccess"
+
+    effect = "Allow"
+
+    actions = [
+      "events:DescribeRule",
+      "events:ListTargetsByRule",
+    ]
+
+    resources = [
+      "arn:aws:events:*:*:rule/${var.name}",
+    ]
   }
 }

--- a/modules/services/event-bridge/organizational.tf
+++ b/modules/services/event-bridge/organizational.tf
@@ -127,6 +127,11 @@ Resources:
                 - Effect: Allow
                   Action: 'events:PutEvents'
                   Resource: ${var.target_event_bus_arn}
+                - Effect: Allow
+                  Action:
+                    - "events:DescribeRule"
+                    - "events:ListTargetsByRule"
+                  Resource: "arn:aws:events:*:*:rule/${var.name}"
 TEMPLATE
 }
 


### PR DESCRIPTION
Adding the following permissions to EB role to be able to run validations. These permissions are targetted to only specific EB rule resource created by the same TF module :-
- events:DescribeRule
- events:ListTargetsByRule

Note: Fixing this for both single and org onboarding case.

<!--
Thank you for your contribution!

## Testing your PR

You can pinpoint the pr changes as terraform module source with following format

```
source                    = "github.com/draios/terraform-aws-secure-for-cloud//examples/organizational-ecs?ref=<BRANCH_NAME>"
```


## General recommendations
Check contribution guidelines at https://github.com/draios/terraform-aws-secure-for-cloud/blob/master/CONTRIBUTE.md#contribution-checklist

For a cleaner PR make sure you follow these recommendations:
- Review modified files and delete small changes that were not intended and maybe slip the commit.
- Use Pull Request Drafts for visibility on Work-In-Progress branches and use them on daily mob/pairing for team review
- Unless an external revision is desired, in order to validate or gather some feedback, you are free to merge as long as **validation checks are green-lighted**

## Checklist

- [ ] If `test/fixtures/*/main.tf` files are modified, update:
    - [ ] the snippets in the README.md file under root folder.
    - [ ] the snippets in the README.md file for the corresponding example.
- [ ] If `examples` folder are modified, update:
    - [ ] README.md file with pertinent changes.
    - [ ] `test/fixtures/*/main.tf` in case the snippet needs modifications.
- [ ] If any architectural change has been made, update the diagrams.

-->
