### PR TITLE
Fix/failure tolerance

### DIFF
--- a/modules/services/agentless-scanning/organizational.tf
+++ b/modules/services/agentless-scanning/organizational.tf
@@ -134,7 +134,6 @@ resource "aws_cloudformation_stack_set_instance" "scanning_role_stackset_instanc
     organizational_unit_ids = local.organizational_unit_ids
   }
   operation_preferences {
-    failure_tolerance_count = 10
     max_concurrent_count    = 10
   }
 }
@@ -206,7 +205,6 @@ resource "aws_cloudformation_stack_set_instance" "mgmt_acc_stackset_instance" {
 
   stack_set_name = aws_cloudformation_stack_set.mgmt_acc_resources_stackset[0].name
   operation_preferences {
-    failure_tolerance_count = 10
     max_concurrent_count    = 10
     region_concurrency_type = "PARALLEL"
   }
@@ -286,7 +284,6 @@ resource "aws_cloudformation_stack_set_instance" "ou_stackset_instance" {
     organizational_unit_ids = local.organizational_unit_ids
   }
   operation_preferences {
-    failure_tolerance_count = 10
     max_concurrent_count    = 10
     region_concurrency_type = "PARALLEL"
   }

--- a/modules/services/agentless-scanning/organizational.tf
+++ b/modules/services/agentless-scanning/organizational.tf
@@ -134,7 +134,7 @@ resource "aws_cloudformation_stack_set_instance" "scanning_role_stackset_instanc
     organizational_unit_ids = local.organizational_unit_ids
   }
   operation_preferences {
-    max_concurrent_count    = 10
+    max_concurrent_count = 10
   }
 }
 

--- a/modules/services/event-bridge/organizational.tf
+++ b/modules/services/event-bridge/organizational.tf
@@ -128,7 +128,6 @@ resource "aws_cloudformation_stack_set_instance" "stackset_instance" {
     organizational_unit_ids = local.organizational_unit_ids
   }
   operation_preferences {
-    failure_tolerance_count = 10
     max_concurrent_count    = 10
     region_concurrency_type = "PARALLEL"
   }
@@ -141,7 +140,6 @@ resource "aws_cloudformation_stack_set_instance" "mgmt_acc_stackset_instance" {
   stack_set_name = aws_cloudformation_stack_set.mgmt-stackset[0].name
 
   operation_preferences {
-    failure_tolerance_count = 10
     max_concurrent_count    = 10
     region_concurrency_type = "PARALLEL"
   }
@@ -156,7 +154,6 @@ resource "aws_cloudformation_stack_set_instance" "eb_role_stackset_instance" {
     organizational_unit_ids = local.organizational_unit_ids
   }
   operation_preferences {
-    failure_tolerance_count = 10
     max_concurrent_count    = 10
     region_concurrency_type = "PARALLEL"
   }

--- a/modules/services/trust-relationship/main.tf
+++ b/modules/services/trust-relationship/main.tf
@@ -162,6 +162,6 @@ resource "aws_cloudformation_stack_set_instance" "stackset_instance" {
     organizational_unit_ids = local.org_units_to_deploy
   }
   operation_preferences {
-    max_concurrent_count    = 10
+    max_concurrent_count = 10
   }
 }

--- a/modules/services/trust-relationship/main.tf
+++ b/modules/services/trust-relationship/main.tf
@@ -162,7 +162,6 @@ resource "aws_cloudformation_stack_set_instance" "stackset_instance" {
     organizational_unit_ids = local.org_units_to_deploy
   }
   operation_preferences {
-    failure_tolerance_count = 10
     max_concurrent_count    = 10
   }
 }

--- a/modules/services/workload-scanning/organizational.tf
+++ b/modules/services/workload-scanning/organizational.tf
@@ -83,7 +83,6 @@ resource "aws_cloudformation_stack_set_instance" "scanning_role_stackset_instanc
     organizational_unit_ids = local.organizational_unit_ids
   }
   operation_preferences {
-    failure_tolerance_count = 10
     max_concurrent_count    = 10
   }
 }

--- a/modules/services/workload-scanning/organizational.tf
+++ b/modules/services/workload-scanning/organizational.tf
@@ -83,6 +83,6 @@ resource "aws_cloudformation_stack_set_instance" "scanning_role_stackset_instanc
     organizational_unit_ids = local.organizational_unit_ids
   }
   operation_preferences {
-    max_concurrent_count    = 10
+    max_concurrent_count = 10
   }
 }


### PR DESCRIPTION
remove `failure_tolerance_count` for stack set instances. This ensures that stack sets instances that may error in sub accounts or regions are always treated as failures during terraform apply.
