### PR TITLE
Add file requested by HashiCorp support to transfer module ownership.

### DIFF
--- a/.terraform-registry
+++ b/.terraform-registry
@@ -1,0 +1,3 @@
+Request: Please transfer ownership of the Terraform Registry module published from this repository from @sameer-in to @sysdig-terraform (Support request #118442)
+Registry Link: https://registry.terraform.io/modules/draios/secure-for-cloud/aws/latest
+Request by: @nkraemer-sysdig


### PR DESCRIPTION
HashiCorp support has requested proof of ownership over this module by adding a specific file.