### PR TITLE
[SSPROD-40007] Adding lambda getRuntimeManagementConfig permission to trust

### DIFF
--- a/modules/services/trust-relationship/main.tf
+++ b/modules/services/trust-relationship/main.tf
@@ -164,6 +164,10 @@ Resources:
                 Effect: "Allow"
                 Action: "macie2:ListClassificationJobs"
                 Resource: "*"
+              - Sid: "GetRuntimeManagementConfig"
+                Effect: "Allow"
+                Action: "lambda:GetRuntimeManagementConfig"
+                Resource: "*"
 TEMPLATE
 }
 

--- a/modules/services/trust-relationship/main.tf
+++ b/modules/services/trust-relationship/main.tf
@@ -89,6 +89,20 @@ data "aws_iam_policy_document" "custom_resources_policy" {
       "*",
     ]
   }
+
+  statement {
+    sid ="GetRuntimeManagementConfig"
+
+    effect = "Allow"
+
+    actions = [
+      "lambda:GetRuntimeManagementConfig",
+    ]
+
+    resources = [
+      "*"
+    ]
+  }
 }
 
 #----------------------------------------------------------

--- a/modules/services/trust-relationship/main.tf
+++ b/modules/services/trust-relationship/main.tf
@@ -91,7 +91,7 @@ data "aws_iam_policy_document" "custom_resources_policy" {
   }
 
   statement {
-    sid ="GetRuntimeManagementConfig"
+    sid = "GetRuntimeManagementConfig"
 
     effect = "Allow"
 


### PR DESCRIPTION
Adding lambda:GetRuntimeManagementConfig permission to CSPM in order to be able to scrap an extra field from AWS Lambda Functions.