### PR TITLE
Use managed-execution in all stacksets

### DIFF
--- a/modules/services/agentless-scanning/organizational.tf
+++ b/modules/services/agentless-scanning/organizational.tf
@@ -34,6 +34,10 @@ resource "aws_cloudformation_stack_set" "scanning_role_stackset" {
   permission_model = "SERVICE_MANAGED"
   capabilities     = ["CAPABILITY_NAMED_IAM"]
 
+  managed_execution {
+    active = true
+  }
+
   auto_deployment {
     enabled                          = true
     retain_stacks_on_account_removal = false
@@ -155,6 +159,10 @@ resource "aws_cloudformation_stack_set" "mgmt_acc_resources_stackset" {
   capabilities            = ["CAPABILITY_NAMED_IAM"]
   administration_role_arn = var.stackset_admin_role_arn
 
+  managed_execution {
+    active = true
+  }
+
   lifecycle {
     ignore_changes = [administration_role_arn]
   }
@@ -224,6 +232,10 @@ resource "aws_cloudformation_stack_set" "ou_resources_stackset" {
   tags             = var.tags
   permission_model = "SERVICE_MANAGED"
   capabilities     = ["CAPABILITY_NAMED_IAM"]
+
+  managed_execution {
+    active = true
+  }
 
   auto_deployment {
     enabled                          = true

--- a/modules/services/event-bridge/organizational.tf
+++ b/modules/services/event-bridge/organizational.tf
@@ -22,6 +22,10 @@ resource "aws_cloudformation_stack_set" "eb-rule-stackset" {
   permission_model = "SERVICE_MANAGED"
   capabilities     = ["CAPABILITY_NAMED_IAM"]
 
+  managed_execution {
+    active = true
+  }
+
   auto_deployment {
     enabled                          = true
     retain_stacks_on_account_removal = false
@@ -49,6 +53,10 @@ resource "aws_cloudformation_stack_set" "mgmt-stackset" {
   capabilities            = ["CAPABILITY_NAMED_IAM"]
   administration_role_arn = var.stackset_admin_role_arn
 
+  managed_execution {
+    active = true
+  }
+
   template_body = templatefile("${path.module}/stackset_template_body.tpl", {
     name                 = var.name
     event_pattern        = var.event_pattern
@@ -65,6 +73,10 @@ resource "aws_cloudformation_stack_set" "eb-role-stackset" {
   tags             = var.tags
   permission_model = "SERVICE_MANAGED"
   capabilities     = ["CAPABILITY_NAMED_IAM"]
+
+  managed_execution {
+    active = true
+  }
 
   auto_deployment {
     enabled                          = true

--- a/modules/services/trust-relationship/main.tf
+++ b/modules/services/trust-relationship/main.tf
@@ -103,6 +103,10 @@ resource "aws_cloudformation_stack_set" "stackset" {
   permission_model = "SERVICE_MANAGED"
   capabilities     = ["CAPABILITY_NAMED_IAM"]
 
+  managed_execution {
+    active = true
+  }
+
   auto_deployment {
     enabled                          = true
     retain_stacks_on_account_removal = false

--- a/modules/services/workload-scanning/organizational.tf
+++ b/modules/services/workload-scanning/organizational.tf
@@ -30,6 +30,10 @@ resource "aws_cloudformation_stack_set" "scanning_role_stackset" {
   permission_model = "SERVICE_MANAGED"
   capabilities     = ["CAPABILITY_NAMED_IAM"]
 
+  managed_execution {
+    active = true
+  }
+
   auto_deployment {
     enabled                          = true
     retain_stacks_on_account_removal = false


### PR DESCRIPTION
Creating a `aws_cloudformation_stack_set_instance` that deploys to multiple regions in paralell  is not yet possible due to https://github.com/hashicorp/terraform-provider-aws/issues/24752, however using the `managed-execution` flag on the `aws_cloudformation_stack_set` resources allows multiple `aws_cloudformation_stack_set_instance` resources to be created in parallel. This has a similar effect, although more objects must be created, potentially neccesitating a higher `-parallelism` flag on `terraform apply`.

This PR enables `managed-execution` for all stacksets created.


Manual testing for a 4 account org, 5 regions, CSPM + EventBridge:

- TF parallelism=10, managed-execution=false
  - Start: 4:05 (destroy: 4:27)
  - End: 4:27 (destroy: 4:40)
  - Duration: 22m (destroy: 13m)

- TF parallelism=10, managed-execution=true
  - Start: 4:40 (destroy: 4:46)
  - End: 4:46 (destroy: 4:49)
  - Duration: 6m (destroy: 3m)

- TF parallelism=100, managed-execution=true
  - Start: 4:50 (destroy: 4:55)
  - End: 4:55 (destroy: 4:57)
  - Duration: 5m (destroy: 2m)