### PR TITLE
[SSPROD-40004] Adding permissions in order to obtain an aws lambda docker image pull string

### DIFF
--- a/modules/services/trust-relationship/main.tf
+++ b/modules/services/trust-relationship/main.tf
@@ -186,6 +186,10 @@ Resources:
                 Effect: "Allow"
                 Action: "lambda:GetRuntimeManagementConfig"
                 Resource: "*"
+              - Sid: "GetFunction"
+                Effect: "Allow"
+                Action: "lambda:GetFunction"
+                Resource: "*"
 TEMPLATE
 }
 

--- a/modules/services/trust-relationship/main.tf
+++ b/modules/services/trust-relationship/main.tf
@@ -91,25 +91,12 @@ data "aws_iam_policy_document" "custom_resources_policy" {
   }
 
   statement {
-    sid = "GetRuntimeManagementConfig"
+    sid = "GetFunctionDetails"
 
     effect = "Allow"
 
     actions = [
       "lambda:GetRuntimeManagementConfig",
-    ]
-
-    resources = [
-      "*"
-    ]
-  }
-
-  statement {
-    sid = "GetFunction"
-
-    effect = "Allow"
-
-    actions = [
       "lambda:GetFunction",
     ]
 
@@ -182,13 +169,11 @@ Resources:
                 Effect: "Allow"
                 Action: "macie2:ListClassificationJobs"
                 Resource: "*"
-              - Sid: "GetRuntimeManagementConfig"
+              - Sid: "GetFunctionDetails"
                 Effect: "Allow"
-                Action: "lambda:GetRuntimeManagementConfig"
-                Resource: "*"
-              - Sid: "GetFunction"
-                Effect: "Allow"
-                Action: "lambda:GetFunction"
+                Action:
+                  - "lambda:GetRuntimeManagementConfig"
+                  - "lambda:GetFunction"
                 Resource: "*"
 TEMPLATE
 }

--- a/modules/services/trust-relationship/main.tf
+++ b/modules/services/trust-relationship/main.tf
@@ -103,6 +103,20 @@ data "aws_iam_policy_document" "custom_resources_policy" {
       "*"
     ]
   }
+
+  statement {
+    sid = "GetFunction"
+
+    effect = "Allow"
+
+    actions = [
+      "lambda:GetFunction",
+    ]
+
+    resources = [
+      "*"
+    ]
+  }
 }
 
 #----------------------------------------------------------


### PR DESCRIPTION
Adding permissions in order to obtain an aws lambda as docker image pull string which is only accessible through the GetFunction call (collector change incoming).