### PR TITLE
fix(agentless-scanning): kms_role_dep

### DIFF
--- a/modules/services/agentless-scanning/organizational.tf
+++ b/modules/services/agentless-scanning/organizational.tf
@@ -300,8 +300,9 @@ TEMPLATE
 
 # stackset instance to deploy resources for agentless scanning, in all regions of each account in all organization units
 resource "aws_cloudformation_stack_set_instance" "ou_stackset_instance" {
-  for_each = local.region_set
-  region   = each.key
+  depends_on = [aws_cloudformation_stack_set_instance.scanning_role_stackset_instance]
+  for_each   = local.region_set
+  region     = each.key
 
   stack_set_name = aws_cloudformation_stack_set.ou_resources_stackset[0].name
   deployment_targets {


### PR DESCRIPTION
* fixes an issue where installation can fail due to an unsatsified role dependency with the regional KMS key under Organization OUs.
