### PR TITLE
feat(event-bridge): add guardduty events, disabled by default (SSPROD-41990)

### DIFF
--- a/.github/workflows/ci-pull-request.yaml
+++ b/.github/workflows/ci-pull-request.yaml
@@ -39,6 +39,7 @@ jobs:
           - "secure_threat_detection_cloud_logs/single/main.tf"
           - "secure_threat_detection_event_bridge/single/main.tf"
           - "secure_config_posture/single/main.tf"
+          - "secure_config_posture/single_guardduty/main.tf"
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci-pull-request.yaml
+++ b/.github/workflows/ci-pull-request.yaml
@@ -38,8 +38,8 @@ jobs:
         example:
           - "secure_threat_detection_cloud_logs/single/main.tf"
           - "secure_threat_detection_event_bridge/single/main.tf"
+          - "secure_threat_detection_event_bridge/single_guardduty/main.tf"
           - "secure_config_posture/single/main.tf"
-          - "secure_config_posture/single_guardduty/main.tf"
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/modules/services/event-bridge/main.tf
+++ b/modules/services/event-bridge/main.tf
@@ -34,7 +34,7 @@ resource "aws_cloudwatch_event_rule" "sysdig" {
   tags        = var.tags
   state       = var.rule_state
 
-  event_pattern = var.event_pattern
+  event_pattern = var.enable_guardduty ? var.event_pattern_guardduty : var.event_pattern
 }
 # Target to forward all CloudTrail events to Sysdig's EventBridge Bus.
 # See https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target#cross-account-event-bus-target

--- a/modules/services/event-bridge/organizational.tf
+++ b/modules/services/event-bridge/organizational.tf
@@ -37,7 +37,7 @@ resource "aws_cloudformation_stack_set" "eb-rule-stackset" {
 
   template_body = templatefile("${path.module}/stackset_template_body.tpl", {
     name                 = var.name
-    event_pattern        = var.event_pattern
+    event_pattern        = var.enable_guardduty ? var.event_pattern_guardduty : var.event_pattern
     rule_state           = var.rule_state
     target_event_bus_arn = var.target_event_bus_arn
   })
@@ -59,7 +59,7 @@ resource "aws_cloudformation_stack_set" "mgmt-stackset" {
 
   template_body = templatefile("${path.module}/stackset_template_body.tpl", {
     name                 = var.name
-    event_pattern        = var.event_pattern
+    event_pattern        = var.enable_guardduty ? var.event_pattern_guardduty : var.event_pattern
     rule_state           = var.rule_state
     target_event_bus_arn = var.target_event_bus_arn
   })

--- a/modules/services/event-bridge/variables.tf
+++ b/modules/services/event-bridge/variables.tf
@@ -87,7 +87,8 @@ variable "event_pattern" {
     "Object Restore Initiated",
     "Object Storage Class Changed",
     "Object Tags Added",
-    "Object Tags Deleted"
+    "Object Tags Deleted",
+    "GuardDuty Finding"
   ]
 }
 EOF

--- a/modules/services/event-bridge/variables.tf
+++ b/modules/services/event-bridge/variables.tf
@@ -87,11 +87,41 @@ variable "event_pattern" {
     "Object Restore Initiated",
     "Object Storage Class Changed",
     "Object Tags Added",
+    "Object Tags Deleted"
+  ]
+}
+EOF
+}
+
+variable "event_pattern_guardduty" {
+  description = "Event pattern for CloudWatch Event Rule with GuardDuty enabled"
+  type        = string
+  default     = <<EOF
+{
+  "detail-type": [
+    "AWS API Call via CloudTrail",
+    "AWS Console Sign In via CloudTrail",
+    "AWS Service Event via CloudTrail",
+    "Object Access Tier Changed",
+    "Object ACL Updated",
+    "Object Created",
+    "Object Deleted",
+    "Object Restore Completed",
+    "Object Restore Expired",
+    "Object Restore Initiated",
+    "Object Storage Class Changed",
+    "Object Tags Added",
     "Object Tags Deleted",
     "GuardDuty Finding"
   ]
 }
 EOF
+}
+
+variable "enable_guardduty" {
+  description = "(Optional) Set this field to 'true' to enabled GuardDuty events"
+  type        = bool
+  default     = false
 }
 
 variable "timeout" {

--- a/test/examples/secure_threat_detection_event_bridge/single_guardduty/main.tf
+++ b/test/examples/secure_threat_detection_event_bridge/single_guardduty/main.tf
@@ -1,0 +1,21 @@
+provider "aws" {
+  region     = "us-east-1"
+  access_key = "test"
+  secret_key = "test"
+
+  endpoints {
+    iam    = "http://127.0.0.1:5000/"
+    sts    = "http://127.0.0.1:5000/"
+    events = "http://127.0.0.1:5000/"
+  }
+}
+
+module "single-account-threat-detection" {
+  source                  = "../../../..//modules/services/event-bridge"
+  target_event_bus_arn    = "arn:aws:events:us-east-1:123456789012:event-bus/falco"
+  trusted_identity        = "arn:aws:iam::123456789012:role/secure-assume-role"
+  external_id             = "external_id"
+  name                    = "secure-threat-detection-single"
+  deploy_global_resources = true
+  enable_guardduty = true
+}


### PR DESCRIPTION
<!--
Thank you for your contribution!

## Testing your PR

You can pinpoint the pr changes as terraform module source with following format

```
source                    = "github.com/draios/terraform-aws-secure-for-cloud//examples/organizational-ecs?ref=<BRANCH_NAME>"
```


## General recommendations
Check contribution guidelines at https://github.com/draios/terraform-aws-secure-for-cloud/blob/master/CONTRIBUTE.md#contribution-checklist

For a cleaner PR make sure you follow these recommendations:
- Review modified files and delete small changes that were not intended and maybe slip the commit.
- Use Pull Request Drafts for visibility on Work-In-Progress branches and use them on daily mob/pairing for team review
- Unless an external revision is desired, in order to validate or gather some feedback, you are free to merge as long as **validation checks are green-lighted**

## Checklist

- [ ] If `test/fixtures/*/main.tf` files are modified, update:
    - [ ] the snippets in the README.md file under root folder.
    - [ ] the snippets in the README.md file for the corresponding example.
- [ ] If `examples` folder are modified, update:
    - [ ] README.md file with pertinent changes.
    - [ ] `test/fixtures/*/main.tf` in case the snippet needs modifications.
- [ ] If any architectural change has been made, update the diagrams.

-->
We are adding guardduty support in FalcoCloud detection, this will deploy a rule in the event bridge that will forward also the guardduty event to cloud ingestion