### PR TITLE
added variable to not deploy management stackset

### DIFF
--- a/modules/services/agentless-scanning/README.md
+++ b/modules/services/agentless-scanning/README.md
@@ -62,6 +62,7 @@ No modules.
 | <a name="input_tags"></a> [tags](#input\_tags) | sysdig secure-for-cloud tags. always include 'product' default tag for resource-group proper functioning | `map(string)` | <pre>{<br>  "product": "sysdig-secure-for-cloud"<br>}</pre> | no |
 | <a name="input_trusted_identity"></a> [trusted\_identity](#input\_trusted\_identity) | The name of sysdig trusted identity | `string` | n/a | yes |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | Stackset instance timeout | `string` | `"30m"` | no |
+| <a name="mgt_stackset"></a> [mgt_stackset](#mgt\_stackset) | Whether to create the resources on the management account using a stackset | `bool` | `true` | no |
 
 ## Outputs
 

--- a/modules/services/agentless-scanning/main.tf
+++ b/modules/services/agentless-scanning/main.tf
@@ -20,7 +20,7 @@
 #-----------------------------------------------------------------------------------------------------------------------
 
 data "aws_iam_policy_document" "scanning" {
-  count = (var.deploy_global_resources || var.is_organizational) ? 1 : 0
+  count = (var.deploy_global_resources || var.is_organizational && var.mgt_stackset) ? 1 : 0
 
   # General read permission, necessary for the discovery phase.
   statement {
@@ -184,7 +184,7 @@ data "aws_iam_policy_document" "scanning" {
 }
 
 resource "aws_iam_policy" "scanning" {
-  count = (var.deploy_global_resources || var.is_organizational) ? 1 : 0
+  count = (var.deploy_global_resources || var.is_organizational && var.mgt_stackset) ? 1 : 0
 
   name        = var.name
   description = "Grants Sysdig Secure access to volumes and snapshots"
@@ -193,7 +193,7 @@ resource "aws_iam_policy" "scanning" {
 }
 
 data "aws_iam_policy_document" "scanning_assume_role_policy" {
-  count = (var.deploy_global_resources || var.is_organizational) ? 1 : 0
+  count = (var.deploy_global_resources || var.is_organizational && var.mgt_stackset) ? 1 : 0
 
   statement {
     sid = "SysdigSecureScanning"
@@ -218,7 +218,7 @@ data "aws_iam_policy_document" "scanning_assume_role_policy" {
 }
 
 resource "aws_iam_role" "scanning" {
-  count = (var.deploy_global_resources || var.is_organizational) ? 1 : 0
+  count = (var.deploy_global_resources || var.is_organizational && var.mgt_stackset) ? 1 : 0
 
   name               = var.name
   tags               = var.tags
@@ -226,7 +226,7 @@ resource "aws_iam_role" "scanning" {
 }
 
 resource "aws_iam_policy_attachment" "scanning" {
-  count = (var.deploy_global_resources || var.is_organizational) ? 1 : 0
+  count = (var.deploy_global_resources || var.is_organizational && var.mgt_stackset) ? 1 : 0
 
   name       = var.name
   roles      = [aws_iam_role.scanning[0].name]

--- a/modules/services/agentless-scanning/organizational.tf
+++ b/modules/services/agentless-scanning/organizational.tf
@@ -156,7 +156,7 @@ resource "aws_cloudformation_stack_set_instance" "scanning_role_stackset_instanc
 
 # stackset to deploy resources for agentless scanning in management account
 resource "aws_cloudformation_stack_set" "mgmt_acc_resources_stackset" {
-  count      = var.is_organizational ? 1 : 0
+  count      = var.is_organizational && var.mgt_stackset ? 1 : 0
   depends_on = [aws_iam_role.scanning]
 
   name                    = join("-", [var.name, "ScanningKmsMgmtAcc"])
@@ -214,7 +214,7 @@ TEMPLATE
 
 # stackset instance to deploy resources for agentless scanning, in all regions of the management account
 resource "aws_cloudformation_stack_set_instance" "mgmt_acc_stackset_instance" {
-  for_each = local.region_set
+  for_each = var.mgt_stackset ? local.region_set : toset([]) 
   region   = each.key
 
   stack_set_name = aws_cloudformation_stack_set.mgmt_acc_resources_stackset[0].name

--- a/modules/services/agentless-scanning/organizational.tf
+++ b/modules/services/agentless-scanning/organizational.tf
@@ -214,7 +214,7 @@ TEMPLATE
 
 # stackset instance to deploy resources for agentless scanning, in all regions of the management account
 resource "aws_cloudformation_stack_set_instance" "mgmt_acc_stackset_instance" {
-  for_each = var.mgt_stackset ? local.region_set : toset([]) 
+  for_each = var.mgt_stackset ? local.region_set : toset([])
   region   = each.key
 
   stack_set_name = aws_cloudformation_stack_set.mgmt_acc_resources_stackset[0].name

--- a/modules/services/agentless-scanning/variables.tf
+++ b/modules/services/agentless-scanning/variables.tf
@@ -74,3 +74,9 @@ variable "timeout" {
   description = "Default timeout values for create, update, and delete operations"
   default     = "30m"
 }
+
+variable "mgt_stackset" {
+  description = "(Optional) Indicates if the management stackset should be deployed"
+  type        = bool
+  default     = true
+}

--- a/modules/services/event-bridge/README.md
+++ b/modules/services/event-bridge/README.md
@@ -59,6 +59,7 @@ No modules.
 | <a name="input_stackset_admin_role_arn"></a> [stackset\_admin\_role\_arn](#input\_stackset\_admin\_role\_arn) | (Optional) stackset admin role to run SELF\_MANAGED stackset | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) Tags to be attached to all Sysdig resources. | `map(string)` | <pre>{<br>  "product": "sysdig"<br>}</pre> | no |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | Stackset instance timeout | `string` | `"30m"` | no |
+| <a name="mgt_stackset"></a> [mgt_stackset](#mgt\_stackset) | Whether to create the resources on the management account using a stackset | `bool` | `true` | no |
 
 ## Outputs
 

--- a/modules/services/event-bridge/main.tf
+++ b/modules/services/event-bridge/main.tf
@@ -56,7 +56,7 @@ resource "aws_cloudwatch_event_target" "sysdig" {
 # Role that will be used by EventBridge when sending events to Sysdig's EventBridge Bus. The EventBridge service is
 # given permission to assume this role.
 resource "aws_iam_role" "event_bus_invoke_remote_event_bus" {
-  count = (var.is_organizational || var.deploy_global_resources) ? 1 : 0
+  count = (var.is_organizational && var.mgt_stackset || var.deploy_global_resources) ? 1 : 0
 
   name = var.name
   tags = var.tags

--- a/modules/services/event-bridge/organizational.tf
+++ b/modules/services/event-bridge/organizational.tf
@@ -45,7 +45,7 @@ resource "aws_cloudformation_stack_set" "eb-rule-stackset" {
 
 # stackset to deploy eventbridge rule in management account
 resource "aws_cloudformation_stack_set" "mgmt-stackset" {
-  count = var.is_organizational ? 1 : 0
+  count = var.is_organizational && var.mgt_stackset ? 1 : 0
 
   name                    = join("-", [var.name, "EBRuleMgmtAcc"])
   tags                    = var.tags
@@ -146,7 +146,7 @@ resource "aws_cloudformation_stack_set_instance" "stackset_instance" {
 
 // stackset instance to deploy rule in all regions of management account
 resource "aws_cloudformation_stack_set_instance" "mgmt_acc_stackset_instance" {
-  for_each       = local.region_set
+  for_each       = var.mgt_stackset ? local.region_set : toset([])
   region         = each.key
   stack_set_name = aws_cloudformation_stack_set.mgmt-stackset[0].name
 

--- a/modules/services/event-bridge/outputs.tf
+++ b/modules/services/event-bridge/outputs.tf
@@ -1,4 +1,4 @@
 output "role_arn" {
-  value       = local.is_role_empty ? aws_iam_role.event_bus_invoke_remote_event_bus[0].arn : ""
+  value       = local.is_role_empty && var.mgt_stackset ? aws_iam_role.event_bus_invoke_remote_event_bus[0].arn : ""
   description = "ARN of cspm role"
 }

--- a/modules/services/event-bridge/variables.tf
+++ b/modules/services/event-bridge/variables.tf
@@ -98,3 +98,9 @@ variable "timeout" {
   description = "Default timeout values for create, update, and delete operations"
   default     = "30m"
 }
+
+variable "mgt_stackset" {
+  description = "(Optional) Indicates if the management stackset should be deployed"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
This PR adds a new variable mgt_stackset to disable stackset creation for the management account as needed. 