### PR TITLE
fix(agentless-scanning): correct caller_arn for assumed roles

### DIFF
--- a/modules/services/agentless-scanning/locals.tf
+++ b/modules/services/agentless-scanning/locals.tf
@@ -1,6 +1,10 @@
 data "aws_caller_identity" "current" {}
+data "aws_iam_session_context" "current" {
+  // Get the source role ARN from the currently assumed session role
+  arn = data.aws_caller_identity.current.arn
+}
 
 locals {
   account_id = data.aws_caller_identity.current.account_id
-  caller_arn = data.aws_caller_identity.current.arn
+  caller_arn = data.aws_iam_session_context.current.issuer_arn
 }


### PR DESCRIPTION
When a role is assumed, the caller identity ARN is an ephemeral session-specific role. Rather than this role in IAM policies, we should use the underlying role that was assumed. This role can be retrieved with `aws_iam_session_context`. More info can be found in [this][1] AWS provider issue.

[1]: https://github.com/hashicorp/terraform-provider-aws/issues/28381

<!--
Thank you for your contribution!

## Testing your PR

You can pinpoint the pr changes as terraform module source with following format

```
source                    = "github.com/draios/terraform-aws-secure-for-cloud//examples/organizational-ecs?ref=<BRANCH_NAME>"
```


## General recommendations
Check contribution guidelines at https://github.com/draios/terraform-aws-secure-for-cloud/blob/master/CONTRIBUTE.md#contribution-checklist

For a cleaner PR make sure you follow these recommendations:
- Review modified files and delete small changes that were not intended and maybe slip the commit.
- Use Pull Request Drafts for visibility on Work-In-Progress branches and use them on daily mob/pairing for team review
- Unless an external revision is desired, in order to validate or gather some feedback, you are free to merge as long as **validation checks are green-lighted**

## Checklist

- [ ] If `test/fixtures/*/main.tf` files are modified, update:
    - [ ] the snippets in the README.md file under root folder.
    - [ ] the snippets in the README.md file for the corresponding example.
- [ ] If `examples` folder are modified, update:
    - [ ] README.md file with pertinent changes.
    - [ ] `test/fixtures/*/main.tf` in case the snippet needs modifications.
- [ ] If any architectural change has been made, update the diagrams.

-->
