### PR TITLE
[SSPROD-48326] Enable agentless KMS key rotation by default for Agentless Host Scanning Key

### DIFF
--- a/modules/services/agentless-scanning/main.tf
+++ b/modules/services/agentless-scanning/main.tf
@@ -303,8 +303,8 @@ resource "aws_kms_key" "scanning" {
 
 # Enable key rotation for the KMS key
 resource "aws_kms_key_rotation" "scanning_rotation" {
-  count = var.is_organizational ? 0 : 1
-  key_id = aws_kms_key.scanning[0].id  # Reference to the KMS key
+  count  = var.is_organizational ? 0 : 1
+  key_id = aws_kms_key.scanning[0].id # Reference to the KMS key
 }
 
 # KMS alias resource only if singleton account

--- a/modules/services/agentless-scanning/main.tf
+++ b/modules/services/agentless-scanning/main.tf
@@ -301,6 +301,12 @@ resource "aws_kms_key" "scanning" {
   tags                    = var.tags
 }
 
+# Enable key rotation for the KMS key
+resource "aws_kms_key_rotation" "scanning_rotation" {
+  count = var.is_organizational ? 0 : 1
+  key_id = aws_kms_key.scanning[0].id  # Reference to the KMS key
+}
+
 # KMS alias resource only if singleton account
 resource "aws_kms_alias" "scanning" {
   count = var.is_organizational ? 0 : 1

--- a/modules/services/agentless-scanning/organizational.tf
+++ b/modules/services/agentless-scanning/organizational.tf
@@ -277,6 +277,7 @@ Resources:
         Description: "Sysdig Agentless Scanning encryption key"
         PendingWindowInDays: ${var.kms_key_deletion_window}
         KeyUsage: "ENCRYPT_DECRYPT"
+        EnableKeyRotation: true   # Enables automatic yearly rotation
         KeyPolicy:
           Id: ${var.name}
           Statement:


### PR DESCRIPTION
With the following changes the KMS key created for Agentless Scanning will be rotated yearly.
This change has been validated by QA as part of:

https://sysdig.atlassian.net/browse/SSPROD-48325